### PR TITLE
fix: update VerityAML URL from demo to production domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
       <p>I am currently a Software Development Engineer II at Amazon Prime Video. I have broad interests in adversarial environments,
         distributed systems, interpreting and building fair AI models.</p>
       <p>Previously co-founded <strong><a href="https://getsonder.io">Sonder</a></strong>, an AI-native search and collaboration platform, with <a href="https://www.linkedin.com/in/jung-yoon-kim/">Yoon Kim</a> (concluded Jan 2026).</p>
-      <p>I'm also building <strong><a href="https://demo.verityaml.com">VerityAML</a></strong> — an AI-native regulatory examination management platform that parses consent orders and examination documents from financial regulators (OCC, FDIC, Federal Reserve, CFPB, and state regulators).</p>
+      <p>I'm also building <strong><a href="https://verityaml.com">VerityAML</a></strong> — an AI-native regulatory examination management platform that parses consent orders and examination documents from financial regulators (OCC, FDIC, Federal Reserve, CFPB, and state regulators).</p>
       <p>Previously built <strong>Stitch</strong>, an AI context portability tool, through the MIT Fuse program.</p>
       <p>I studied Computer Science at the University of Bristol, achieving First Class Honours.</p>
       <p>When I'm not coding, you can find me reading, running, and eating. But mostly running.</p>
@@ -251,7 +251,7 @@
       <ul class="project-list">
         <li>
           <div class="project-title">
-            <a href="https://demo.verityaml.com">VerityAML</a>
+            <a href="https://verityaml.com">VerityAML</a>
           </div>
           <div class="project-description">AI-native platform for managing regulatory examinations. Parses documents from OCC, FDIC, CFPB, and state regulators.</div>
         </li>


### PR DESCRIPTION
## Summary
- Update VerityAML link from `demo.verityaml.com` to `verityaml.com` in both the bio section and Projects section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VerityAML hyperlinks to point to the production URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->