### PR TITLE
fix: rename VerityAML to Verity and update product description

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
       <p>I am currently a Software Development Engineer II at Amazon Prime Video. I have broad interests in adversarial environments,
         distributed systems, interpreting and building fair AI models.</p>
       <p>Previously co-founded <strong><a href="https://getsonder.io">Sonder</a></strong>, an AI-native search and collaboration platform, with <a href="https://www.linkedin.com/in/jung-yoon-kim/">Yoon Kim</a> (concluded Jan 2026).</p>
-      <p>I'm also building <strong><a href="https://verityaml.com">VerityAML</a></strong> — an AI-native regulatory examination management platform that parses consent orders and examination documents from financial regulators (OCC, FDIC, Federal Reserve, CFPB, and state regulators).</p>
+      <p>I'm also building <strong><a href="https://verityaml.com">Verity</a></strong> — the governance layer for compliance program effectiveness. Verity helps compliance teams continuously prove their programs work, with scored criteria, evidence tracking, and examination document parsing mapped to the FFIEC framework.</p>
       <p>Previously built <strong>Stitch</strong>, an AI context portability tool, through the MIT Fuse program.</p>
       <p>I studied Computer Science at the University of Bristol, achieving First Class Honours.</p>
       <p>When I'm not coding, you can find me reading, running, and eating. But mostly running.</p>
@@ -251,9 +251,9 @@
       <ul class="project-list">
         <li>
           <div class="project-title">
-            <a href="https://verityaml.com">VerityAML</a>
+            <a href="https://verityaml.com">Verity</a>
           </div>
-          <div class="project-description">AI-native platform for managing regulatory examinations. Parses documents from OCC, FDIC, CFPB, and state regulators.</div>
+          <div class="project-description">The governance layer for compliance program effectiveness. Monitor readiness across regulatory domains, parse examination request letters into trackable items mapped to the FFIEC framework, and manage evidence collection.</div>
         </li>
         <li>
           <div class="project-title">Stitch</div>


### PR DESCRIPTION
## Summary
- Rename VerityAML → Verity in bio and Projects section
- Update description to match verityaml.com positioning: governance layer for compliance program effectiveness, scored criteria, evidence tracking, FFIEC-mapped examination parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)