### PR TITLE
Revert covid-sentiment iframe embeds to static images

### DIFF
--- a/articles/covid-sentiment/index.html
+++ b/articles/covid-sentiment/index.html
@@ -50,24 +50,6 @@
       display: block;
     }
 
-    .visualization-container iframe {
-      width: 100%;
-      height: 480px;
-      border: 0;
-      display: block;
-      background-color: transparent;
-    }
-
-    .visualization-container iframe.table-embed {
-      height: 360px;
-    }
-
-    @media (max-width: 600px) {
-      .visualization-container iframe {
-        height: 380px;
-      }
-    }
-
     .chart-note {
       font-size: 0.8rem;
       font-style: italic;
@@ -145,11 +127,6 @@
           this was to prove a point to my friend and not supposed to be submitted to a scientific journal.
           You'll understand why below.
         </p>
-        <p>
-          The full interactive playground lives <a
-            href="https://ckallum.com/uk-covid-twitter-sentiment-nlp/"><u><strong>here</strong></u></a>.
-          The graphs embedded below are live views of it — poke, zoom, and filter to your heart's content.
-        </p>
         <h2>Getting good data is hard.</h2>
         <p>
           Okay we all understand the importance of data but boy did I not prepare myself how hard it was to actually
@@ -211,8 +188,7 @@
 
 
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=models-covid"
-                  loading="lazy" title="NLP model comparison — COVID dataset"></iframe>
+          <img src="./images/covid-sentiment-models.png" alt="NLP Model Comparison - Covid Dataset">
           <p class="chart-note"> [COVID-19 Dataset]</p>
         </div>
 
@@ -222,8 +198,7 @@
           is mostly positive between models. Naive-Bayes is perhaps overly optimistic?</p>
 
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=models-lockdown"
-                  loading="lazy" title="NLP model comparison — Lockdown dataset"></iframe>
+          <img src="./images/lockdown-sentiment-models.png" alt="NLP Model Comparison - Lockdown Dataset">
           <p class="chart-note"> [Lockdown Dataset]</p>
         </div>
 
@@ -248,8 +223,7 @@
           the Scottish population were less likely to be happy with Boris Johnson due to
           the political climate (Brexit, Indepedence etc). Callum 1-0 Bob
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=country-sentiment"
-                  loading="lazy" title="Sentiment across countries 2020–2021"></iframe>
+          <img src="./images/country-sentiment-chart.png" alt="">
           <p class="chart-note">Naive-Bayes: Sentiment across countries 2020-2021</p>
         </div>
 
@@ -261,9 +235,7 @@
 
         </p>
         <div class="visualization-container">
-          <iframe class="table-embed"
-                  src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=county-table"
-                  loading="lazy" title="Happiest and saddest counties"></iframe>
+          <img src="./images/sentiment-table-county.png" alt="">
           <p class="chart-note">Naive-Bayes: Happiest and saddest counties</p>
         </div>
 
@@ -280,8 +252,7 @@
         </p>
 
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=rates-england-covid"
-                  loading="lazy" title="England — Sentiment vs COVID infection and death rates"></iframe>
+          <img src="./images/covid-sentiment-rates-england.png">
           <p class="chart-note">[Naive Bayes] Sentiment vs COVID infection and death rates.</p>
         </div>
 
@@ -304,9 +275,7 @@
 
 
         <div class="visualization-container">
-          <iframe class="table-embed"
-                  src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=overall-table"
-                  loading="lazy" title="Overall statistics"></iframe>
+          <img src="./images/sentiment-table-overall.png" alt="">
           <p class="chart-note">Statistic Overview</p>
         </div>
 
@@ -321,8 +290,7 @@
         </p>
 
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=rates-england-lockdown"
-                  loading="lazy" title="England — Lockdown sentiment vs COVID rates"></iframe>
+          <img src="./images/lockdown-sentiment-rates-england.png">
           <p class="chart-note">[England, Naive-Bayes] Lockdown Sentiment versus Covid Rates</p>
         </div>
 
@@ -332,8 +300,7 @@
           announced the people of the UK can ’turn the tide of coronavirus’ within 12 weeks.</p>
 
         <div class="visualization-container">
-          <iframe src="https://ckallum.com/uk-covid-twitter-sentiment-nlp/?embed=1&chart=rates-england-covid"
-                  loading="lazy" title="England — COVID sentiment vs COVID rates"></iframe>
+          <img src="./images/covid-sentiment-rates-england.png">
           <p class="chart-note">[England, Naive-Bayes] COVID Sentiment versus Covid Rates</p>
         </div>
 


### PR DESCRIPTION
## Summary
- Reverted all 8 iframe embeds in the covid-sentiment article back to the original static images
- Removed iframe-specific CSS (height, responsive styles, table-embed class)
- Removed the "interactive playground" paragraph that referenced the embed feature

## Why
The iframe embed mode (`?embed=1&chart=...`) was rendering the NLP playground's home page for every chart instead of the specific graph. This made all visualization sections show identical, incorrect content.

Static images restore the correct visuals until embed routing on the NLP playground is fixed.

## Test plan
- [x] Verify all 8 chart images load correctly on the covid-sentiment article page
- [x] Check responsive layout still works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)