### PR TITLE
fix(covid-sentiment): move data exploration link to intro section

### DIFF
--- a/articles/covid-sentiment/index.html
+++ b/articles/covid-sentiment/index.html
@@ -125,8 +125,10 @@
         <p>
           Needless to say, please do take any conclusions I make with a heavy tablespoon of salt. Again,
           this was to prove a point to my friend and not supposed to be submitted to a scientific journal.
-          You'll understand why below.
+          You'll understand why below. Enough rambling, have fun exploring the data <a
+            href="https://ckallum.com/uk-covid-twitter-sentiment-nlp/"> <u><strong>here.</strong></u></a>
         </p>
+
         <h2>Getting good data is hard.</h2>
         <p>
           Okay we all understand the importance of data but boy did I not prepare myself how hard it was to actually
@@ -332,8 +334,6 @@
           <img src="./images/word-cloud.png" alt="Word Cloud">
         </div>
 
-        <p>Enough rambling, have fun exploring the data <a
-            href="https://ckallum.com/uk-covid-twitter-sentiment-nlp/"> <u><strong>here.</strong></u></a></p>
 
         </p>
 


### PR DESCRIPTION
## Summary
- Moved the "have fun exploring the data" link from the bottom of the page to inline within the introductory paragraphs
- Improves visibility and reading flow by placing the interactive data link where readers first encounter the article summary

## Test plan
- [ ] Verify the link appears at the end of the intro section
- [ ] Verify the link is no longer at the bottom of the page
- [ ] Confirm the link navigates to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)